### PR TITLE
Add pkgconfig to the installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.13
-RUN apk add autoconf automake autoconf-archive
+RUN apk add autoconf automake autoconf-archive pkgconfig
 ADD entry.sh /
 
 VOLUME /src


### PR DESCRIPTION
Running `autoreconf` without `pkgconfig` doesn't include the appropiate macros. See https://bugs.python.org/issue45350 for more information